### PR TITLE
Fixed deserialize metaconfig.xml on every page view #7

### DIFF
--- a/source/newtelligence.DasBlog.Web.Core/SeoMetaTags.cs
+++ b/source/newtelligence.DasBlog.Web.Core/SeoMetaTags.cs
@@ -22,6 +22,18 @@ namespace newtelligence.DasBlog.Web.Core
 
         public SeoMetaTags GetMetaTags()
         {
+            var cache = CacheFactory.GetCache();                   
+            var seoMetaTags = cache["seoMetaTags"] as SeoMetaTags;            
+            if (seoMetaTags == null)
+            {
+                seoMetaTags = GetMetaTagsFromConfig();
+                cache.Insert("seoMetaTags", seoMetaTags, new System.Web.Caching.CacheDependency(MetaConfigFile));                
+            }
+            return seoMetaTags;
+        }
+        
+        private SeoMetaTags GetMetaTagsFromConfig()
+        {
             if (!File.Exists(MetaConfigFile))
             {
                 return null;


### PR DESCRIPTION
Use a cache to avoid reading and parsing the metaConfig.xml file on
every page view.
